### PR TITLE
#1 - deploy workflow fixed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
I noticed that deploy is programmed to fire on every push on `master` branch, but our main in branch is called `main`. This change should fix it.