### PR TITLE
#55 - mobile img fix

### DIFF
--- a/frontend/views/Landing.vue
+++ b/frontend/views/Landing.vue
@@ -158,7 +158,7 @@
         </main>
       </div>
     </div>
-    <div class="lg:absolute lg:inset-y-0 lg:right-0 lg:w-1/2">
+    <div class="hidden lg:block lg:absolute lg:inset-y-0 lg:right-0 lg:w-1/2">
       <img
         class="h-56 w-full object-cover sm:h-72 md:h-96 lg:w-full lg:h-full"
         src="https://images.unsplash.com/photo-1566647387313-9fda80664848?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2602&q=80"


### PR DESCRIPTION
This PR should close #55 

Mobile version images seemed overwhelming so we are hiding one untill the resolution is at least 1024px.
Before:
![land mob b](https://user-images.githubusercontent.com/39692087/126643514-261b3f33-9de4-471f-95c9-1eb2a07e8c33.png)
After:
![land mob a](https://user-images.githubusercontent.com/39692087/126643575-35c0349d-0602-4b9b-8c10-8b63902d9ab5.png)

