### PR TITLE
#35 - removed git hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,16 +46,7 @@
     "> 1%",
     "last 2 versions",
     "not dead"
-  ],
-  "gitHooks": {
-    "pre-commit": "lint-staged"
-  },
-
-  "lint-staged": {
-    "*.{js,jsx,vue}": [
-      "vue-cli-service lint",
-      "git add"
-    ]
-  }
+  ]
+  
   
 }


### PR DESCRIPTION
This PR should close #35 

This git hook was installed at the beggining of our project by Vue CLI, because we are using docker in this app it caused problems. Not to mention, that we are already using lint on save so git hook was kinda unnecessary.