### PR TITLE
#1 - removed label types from title action

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -5,8 +5,6 @@ on:
       - opened
       - edited
       - synchronize
-      - labeled
-      - unlabeled
 
 jobs:
   check-pr-title:


### PR DESCRIPTION
It seems label/unlabel actions are creating multiple checks, based on amount of labels assigned.

I don't think those are necessary, because title isn't edited in this operation, and there's separate event for editing/pushing/etc.