### PR TITLE
#69 - implement company cache to filters

### DIFF
--- a/backend/Collectors/UniqueCollector.php
+++ b/backend/Collectors/UniqueCollector.php
@@ -24,15 +24,18 @@ abstract class UniqueCollector implements JsonSerializable
         $this->collectedContent = [];
     }
 
-    public function collectAndGetID(string $content): int
+    public function collectAndGetID(string $content, int $matchId): int
     {
         foreach ($this->collectedContent as $collected) {
             if ($collected->getCollectedName() === $content) {
+                $collected->pushMatchId($matchId);
                 return $collected->getID();
             }
         }
         $newId = $this->nextIdToAssign++;
-        array_push($this->collectedContent, new CollectedContent($newId, $content));
+        $collectedItem = new CollectedContent($newId, $content);
+        $collectedItem->pushMatchId($matchId);
+        array_push($this->collectedContent, $collectedItem);
         return $newId;
     }
 

--- a/backend/Factories/CompanyDataFactory.php
+++ b/backend/Factories/CompanyDataFactory.php
@@ -88,12 +88,12 @@ class CompanyDataFactory extends DataFactory implements SerializableInfo
             $entryId
         );
 
-        $tagIDs = [];
+        $tagIds = [];
         $tagCollector = $this->filterCollector->getTagCollector();
         foreach ($entry["tags"] as $tag) {
-            array_push($tagIDs, $tagCollector->collectAndGetID($tag, $entryId));
+            array_push($tagIds, $tagCollector->collectAndGetID($tag, $entryId));
         }
-        $entry["tags"] = array_unique($tagIDs, SORT_NUMERIC);
+        $entry["tags"] = array_unique($tagIds, SORT_NUMERIC);
 
         return $entry;
     }

--- a/backend/Factories/CompanyDataFactory.php
+++ b/backend/Factories/CompanyDataFactory.php
@@ -78,19 +78,20 @@ class CompanyDataFactory extends DataFactory implements SerializableInfo
         ];
     }
 
-    public function processEntry(array $entry): array
+    public function processEntry(int $entryId, array $entry): array
     {
-        $entry["country"] = $this->filterCollector->getCountryCollector()->collectAndGetID($entry["country"]);
-        $entry["city"] = $this->filterCollector->getCityCollector()->collectAndGetID($entry["city"]);
+        $entry["country"] = $this->filterCollector->getCountryCollector()->collectAndGetID($entry["country"], $entryId);
+        $entry["city"] = $this->filterCollector->getCityCollector()->collectAndGetID($entry["city"], $entryId);
 
         $entry["specialization"] = $this->filterCollector->getSpecializationCollector()->collectAndGetID(
-            $entry["specialization"]
+            $entry["specialization"],
+            $entryId
         );
 
         $tagIDs = [];
         $tagCollector = $this->filterCollector->getTagCollector();
         foreach ($entry["tags"] as $tag) {
-            array_push($tagIDs, $tagCollector->collectAndGetID($tag));
+            array_push($tagIDs, $tagCollector->collectAndGetID($tag, $entryId));
         }
         $entry["tags"] = array_unique($tagIDs, SORT_NUMERIC);
 

--- a/backend/Factories/DataFactory.php
+++ b/backend/Factories/DataFactory.php
@@ -99,7 +99,7 @@ abstract class DataFactory implements BuildTool, SerializableInfo
             if ($rowNumber > 0) {
                 $entry = array_combine(array_keys($this->fields), array_values($rowData));
                 $jsonID = $rowNumber - 1;
-                $preparedEntry = $this->processEntry($this->validate($jsonID, $entry));
+                $preparedEntry = $this->processEntry($jsonID, $this->validate($jsonID, $entry));
                 $modelObject = new $modelName($jsonID, $preparedEntry);
                 array_push($dataObjects, $modelObject);
             }

--- a/backend/Factories/DataFactory.php
+++ b/backend/Factories/DataFactory.php
@@ -98,9 +98,9 @@ abstract class DataFactory implements BuildTool, SerializableInfo
         foreach ($csvData as $rowNumber => $rowData) {
             if ($rowNumber > 0) {
                 $entry = array_combine(array_keys($this->fields), array_values($rowData));
-                $jsonID = $rowNumber - 1;
-                $preparedEntry = $this->processEntry($jsonID, $this->validate($jsonID, $entry));
-                $modelObject = new $modelName($jsonID, $preparedEntry);
+                $jsonId = $rowNumber - 1;
+                $preparedEntry = $this->processEntry($jsonId, $this->validate($jsonId, $entry));
+                $modelObject = new $modelName($jsonId, $preparedEntry);
                 array_push($dataObjects, $modelObject);
             }
         }

--- a/backend/Factories/FacultyDataFactory.php
+++ b/backend/Factories/FacultyDataFactory.php
@@ -31,7 +31,7 @@ class FacultyDataFactory extends DataFactory
         ];
     }
 
-    public function processEntry(array $entry): array
+    public function processEntry(int $entryId, array $entry): array
     {
         return $entry;
     }

--- a/backend/Interfaces/BuildTool.php
+++ b/backend/Interfaces/BuildTool.php
@@ -16,7 +16,7 @@ interface BuildTool
 
     public function setPaths(): void;
 
-    public function processEntry(array $entry): array;
+    public function processEntry(int $entryId, array $entry): array;
 
     public function onBuildStart();
 

--- a/backend/Models/CollectedContent.php
+++ b/backend/Models/CollectedContent.php
@@ -20,6 +20,11 @@ class CollectedContent implements JsonSerializable
         $this->collectedName = $collectedName;
     }
 
+    public function pushMatchId(int $id): void
+    {
+        array_push($this->matchIds, $id);
+    }
+
     public function getID(): int
     {
         return $this->id;

--- a/backend/Models/CollectedContent.php
+++ b/backend/Models/CollectedContent.php
@@ -8,11 +8,14 @@ use JsonSerializable;
 
 class CollectedContent implements JsonSerializable
 {
+    /** @var int[] */
+    protected array $matchIds;
     protected int $id;
     protected string $collectedName;
 
     public function __construct(int $id, string $collectedName)
     {
+        $this->matchIds = [];
         $this->id = $id;
         $this->collectedName = $collectedName;
     }
@@ -32,6 +35,7 @@ class CollectedContent implements JsonSerializable
         return [
             "id" => $this->id,
             "name" => $this->collectedName,
+            "matchIds" => $this->matchIds,
         ];
     }
 }

--- a/resources/faculties/wydzial-techniczny/companies.csv
+++ b/resources/faculties/wydzial-techniczny/companies.csv
@@ -51,7 +51,7 @@
 "ADVATECH Sp. z o.o.","Polska","51.106054,16.971170","Wrocławski Park Technologiczny-Budynek Alfa, Klecińska 123","54-413","Wrocław","Informatyka","IT","https://www.advatech.pl/","info@advatech.pl","71 772 66 00","Nie",,,
 "Etteplan Poland Sp. z o.o.","Polska","51.116657,16.996810","Legnicka 48g","54-202","Wrocław","Informatyka","IT","https://www.etteplan.com/pl/kontakt","maciej.sibinski@etteplan.com","668 181 511","Nie",,,
 "ITMdevlabs sp z o.o","Polska","51.201574,16.154070","Macieja Rataja 21","59-220","Legnica","Informatyka","IT","https://itmdevlabs.com/","office@itmdevlabs.com","71 718 37 10","Nie",,,
-"ITMation S.A.","Polska","51.070151,17.013740","Okrężna 10","53-008","Wrocław","Informatyka","Web, Hosting,","https://itmation.pl/","biuro@itmation.pl","71 718 37 10","Nie",,,
+"ITMation S.A.","Polska","51.070151,17.013740","Okrężna 10","53-008","Wrocław","Informatyka","Web, Hosting","https://itmation.pl/","biuro@itmation.pl","71 718 37 10","Nie",,,
 "Better Software Group S.A.","Polska","51.100089,17.031190","Komandorska 12","50-022","Wrocław","Informatyka","Programowanie, Grafika","https://www.bsgroup.eu/",,,"Nie",,,
 "YUMA Przedsiębiorstwo Informatyczne Sp. z o.o.","Polska","51.063763,16.981610","Wałbrzyska 12","52-314","Wrocław","Informatyka","IT, Serwis, Programowanie","http://www.yuma.pl/","kontakt@yuma.pl","71 78 44 100","Nie",,,
 "Adeo Screen sp. z o.o.","Polska","51.108364,15.921550","Bolesława Krzywoustego 31","59-500","Złotoryja","Informatyka","IT","http://www.adeoscreen.com/","info@adeoscreen.pl","76 850 53 01","Nie",,,


### PR DESCRIPTION
It should close #69.

Change intended to make searching light-weight, to remove the need to parse company data to find matching filters.