### PR TITLE
#112 - added style loading from github secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Install and build frontend
         env:
           VUE_APP_MAPBOX_TOKEN: "${{ secrets.VUE_APP_MAPBOX_TOKEN }}"
+          VUE_APP_MAPBOX_STYLE_URL: "${{ secrets.VUE_APP_MAPBOX_STYLE_URL }}"
+          MAPBOX_TOKEN: "${{ secrets.VUE_APP_MAPBOX_TOKEN }}"
+
         run: |
           npm install
           npm run-script build


### PR DESCRIPTION
This PR should close #112 

I forgot that deploy won't follow our instructions from readme so static given style in env.example won't be copied to .env file. That's why the style wasn't loading correctly. Also loading secret token to backend mapbox variable was added. 